### PR TITLE
Add handling for empty user info in X API response

### DIFF
--- a/app/jobs/update_user_images_job.rb
+++ b/app/jobs/update_user_images_job.rb
@@ -25,6 +25,9 @@ class UpdateUserImagesJob < ApplicationJob
           user.deactivate
           logger.info "No refresh token: #{user.id}"
           result.deactivated << user.twitter_screen_name
+        rescue User::EmptyUserInfoError
+          logger.warn 'X API returned an empty user'
+          result.failed << user.twitter_screen_name
         rescue TwitterClient::BadRequestError => e
           if e.body['error_description'] == 'Value passed for the token was invalid.'
             user.deactivate

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ApplicationRecord
   class NoRefreshTokenError < StandardError; end
+  class EmptyUserInfoError < StandardError; end
 
   belongs_to :student
   has_one :twitter_credential, dependent: :destroy
@@ -49,9 +50,9 @@ class User < ApplicationRecord
 
     client = TwitterClient.with_oauth2(bearer_token: token)
     response = client.me({ 'user.fields' => 'profile_image_url' })
-    Rails.logger.info(response)
-    data = response.fetch('data')
+    raise EmptyUserInfoError if response.empty?
 
+    data = response.fetch('data')
     update!(
       twitter_screen_name: data.fetch('username'),
       image_url: data.fetch('profile_image_url'),


### PR DESCRIPTION
To handle the following error:

```
KeyError: key not found: "data" (KeyError)
  from app/models/user.rb:53:in `fetch'
  from app/models/user.rb:53:in `fetch_and_update!'
  from app/jobs/update_user_images_job.rb:21:in `block in UpdateUserImagesJob#perform'
  from active_record/relation/batches.rb:88:in `each'
  from active_record/relation/batches.rb:88:in `block in ActiveRecord::Batches#find_each'
  from active_record/relation/batches.rb:172:in `block in ActiveRecord::Batches#find_in_batches'
  from active_record/relation/batches.rb:461:in `block in ActiveRecord::Batches#batch_on_unloaded_relation'
  from <internal:kernel>:168:in `loop'
  from active_record/relation/batches.rb:434:in `batch_on_unloaded_relation'
  from active_record/relation/batches.rb:289:in `in_batches'
  from active_record/relation/batches.rb:171:in `find_in_batches'
  from active_record/relation/batches.rb:87:in `find_each'
  from app/jobs/update_user_images_job.rb:10:in `perform'
  from active_job/execution.rb:68:in `block in ActiveJob::Execution#_perform_job'
  from active_support/callbacks.rb:120:in `block in ActiveSupport::Callbacks#run_callbacks'
  from i18n.rb:348:in `with_locale'
  from active_job/translation.rb:9:in `block (2 levels) in <module:Translation>'
  from active_support/callbacks.rb:129:in `instance_exec'
  from active_support/callbacks.rb:129:in `block in ActiveSupport::Callbacks#run_callbacks'
  from active_support/core_ext/time/zones.rb:65:in `Time.use_zone'
  from active_job/timezones.rb:9:in `block (2 levels) in <module:Timezones>'
  from active_support/callbacks.rb:129:in `instance_exec'
  from active_support/callbacks.rb:129:in `block in ActiveSupport::Callbacks#run_callbacks'
  from active_support/callbacks.rb:140:in `run_callbacks'
  from active_job/execution.rb:67:in `_perform_job'
  from active_job/instrumentation.rb:32:in `_perform_job'
  from active_job/execution.rb:51:in `perform_now'
  from active_job/instrumentation.rb:26:in `block in ActiveJob::Instrumentation#perform_now'
  from active_record/railties/job_runtime.rb:13:in `block in ActiveRecord::Railties::JobRuntime#instrument'
  from active_job/instrumentation.rb:40:in `block in ActiveJob::Instrumentation#instrument'
  from active_support/notifications.rb:210:in `block in ActiveSupport::Notifications.instrument'
  from active_support/notifications/instrumenter.rb:58:in `instrument'
  from active_support/notifications.rb:210:in `ActiveSupport::Notifications.instrument'
  from active_job/instrumentation.rb:39:in `instrument'
  from active_record/railties/job_runtime.rb:11:in `instrument'
  from active_job/instrumentation.rb:26:in `perform_now'
  from active_job/logging.rb:32:in `block in ActiveJob::Logging#perform_now'
  from active_support/tagged_logging.rb:143:in `block in ActiveSupport::TaggedLogging#tagged'
  from active_support/tagged_logging.rb:38:in `tagged'
  from active_support/tagged_logging.rb:143:in `tagged'
  from active_support/broadcast_logger.rb:241:in `method_missing'
  from active_job/logging.rb:39:in `tag_logger'
  from active_job/logging.rb:32:in `perform_now'
  from sentry/rails/active_job.rb:11:in `block in Sentry::Rails::ActiveJobExtensions#perform_now'
  from sentry/rails/active_job.rb:43:in `block in Sentry::Rails::ActiveJobExtensions::SentryReporter.record'
  from sentry/hub.rb:59:in `with_scope'
  from sentry-ruby.rb:400:in `Sentry.with_scope'
  from sentry/rails/active_job.rb:26:in `Sentry::Rails::ActiveJobExtensions::SentryReporter.record'
  from sentry/rails/active_job.rb:10:in `perform_now'
  from active_job/execution.rb:23:in `perform_now'
  from lib/tasks/genron_sf.rake:19:in `block (2 levels) in <main>'
  from rake/task.rb:281:in `block in Rake::Task#execute'
  from rake/task.rb:281:in `each'
  from rake/task.rb:281:in `execute'
  from rake/task.rb:219:in `block in Rake::Task#invoke_with_call_chain'
  from rake/task.rb:199:in `synchronize'
  from rake/task.rb:199:in `invoke_with_call_chain'
  from rake/task.rb:188:in `invoke'
  from rake/application.rb:188:in `invoke_task'
  from rake/application.rb:138:in `block (2 levels) in Rake::Application#top_level'
  from rake/application.rb:138:in `each'
  from rake/application.rb:138:in `block in Rake::Application#top_level'
  from rake/application.rb:147:in `run_with_threads'
  from rake/application.rb:132:in `top_level'
  from rake/application.rb:83:in `block in Rake::Application#run'
  from rake/application.rb:214:in `standard_exception_handling'
  from rake/application.rb:80:in `run'
  from bin/rake:4:in `<main>'
```

Maybe the X API https://docs.x.com/x-api/users/user-lookup-me returns an empty response with a 200 status code when the user has been deactivated

![x com_yoakero(iPad Mini)](https://github.com/user-attachments/assets/f26b5e08-b03b-44a9-b1ce-e8f90199a67f)
