### PR TITLE
Reduce URL-bearing X posts

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
 
+      - run: sudo apt-get update && sudo apt-get install -y libidn-dev
+
       - uses: ruby/setup-ruby@v1.310.0
         with:
           bundler-cache: true
@@ -23,6 +25,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4.2.2
+
+      - run: sudo apt-get update && sudo apt-get install -y libidn-dev
 
       - uses: ruby/setup-ruby@v1.310.0
         with:
@@ -45,6 +49,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4.2.2
+
+      - run: sudo apt-get update && sudo apt-get install -y libidn-dev
 
       - uses: ruby/setup-ruby@v1.310.0
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'ridgepole', require: false
 gem 'scout_apm'
 gem 'sentry-rails'
 gem 'sentry-ruby'
+gem 'twitter-text'
 
 gem 'genron_sf', github: 'fuji-nakahara/genron_sf', branch: 'main', require: 'genron_sf/ebook'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,7 @@ GEM
     hashie (5.0.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    idn-ruby (0.1.5)
     io-console (0.8.0)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -378,8 +379,14 @@ GEM
     stringio (3.1.6)
     thor (1.4.0)
     timeout (0.4.3)
+    twitter-text (3.1.0)
+      idn-ruby
+      unf (~> 0.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.9.1)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -408,6 +415,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES
@@ -448,6 +456,7 @@ DEPENDENCIES
   sentry-ruby
   simple_oauth
   sprockets-rails
+  twitter-text
   web-console
   webmock
 

--- a/app/jobs/tweet_imported_job.rb
+++ b/app/jobs/tweet_imported_job.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class TweetImportedJob < ApplicationJob
+  include Twitter::TwitterText::Validation
+
+  MAX_TWEET_WEIGHTED_LENGTH = 270
   Error = Class.new(StandardError)
 
   def perform
@@ -16,12 +19,21 @@ class TweetImportedJob < ApplicationJob
     end
 
     works = Work.where(kadai: Kadai.newest3, tweet_id: nil).where.not(genron_sf_id: nil).order(:id)
-    works.includes(student: :user).find_each do |work|
-      tweet = post_tweet(work_tweet_text(work))
-      if tweet
-        work.update!(tweet_id: tweet.fetch('data').fetch('id'))
-      else
-        failed[:work_ids] << work.id
+    works.includes(:kadai, student: :user)
+         .group_by { |work| [work.kadai, work.type] }
+         .each do |(kadai, type), grouped_works|
+      if kadai.tweet_id.nil?
+        failed[:work_ids] += grouped_works.map(&:id)
+        next
+      end
+
+      work_tweet_chunks(type, grouped_works).each do |text, chunk_works|
+        tweet = post_tweet(text, reply_to: kadai.tweet_id)
+        if tweet
+          chunk_works.each { |work| work.update!(tweet_id: tweet.fetch('data').fetch('id')) }
+        else
+          failed[:work_ids] += chunk_works.map(&:id)
+        end
       end
     end
 
@@ -42,20 +54,47 @@ class TweetImportedJob < ApplicationJob
     lines.join("\n")
   end
 
-  def work_tweet_text(work)
+  def work_tweet_chunks(type, works)
+    chunks = []
     lines = []
-    lines << if work.student.user
-               "【#{work.class.model_name.human}】#{work.student.name} @#{work.student.user.twitter_screen_name}『#{work.title}』" # rubocop:disable Layout/LineLength
-             else
-               "【#{work.class.model_name.human}】#{work.student.name}『#{work.title}』"
-             end
-    lines << '#SF創作講座'
-    lines << work.url
-    lines.join("\n")
+    chunk_works = []
+
+    works.each do |work|
+      line = work_tweet_line(work)
+      next_text = work_tweet_text(type, lines + [line])
+      tweet_weighted_length = parse_tweet(next_text)[:weighted_length]
+      if lines.present? && tweet_weighted_length > MAX_TWEET_WEIGHTED_LENGTH
+        chunks << [work_tweet_text(type, lines), chunk_works]
+        lines = []
+        chunk_works = []
+      end
+
+      lines << line
+      chunk_works << work
+    end
+
+    chunks << [work_tweet_text(type, lines), chunk_works] if lines.present?
+    chunks
   end
 
-  def post_tweet(text)
-    Rails.configuration.x.twitter_client.tweet(text)
+  def work_tweet_line(work)
+    author = work.student.name
+    author = "#{author} @#{work.student.user.twitter_screen_name}" if work.student.user
+    "#{author}『#{work.title}』"
+  end
+
+  def work_tweet_text(type, lines)
+    header = "#{type.constantize.model_name.human}が投稿されました！"
+    footer = '#SF創作講座'
+    ([header] + lines + [footer]).join("\n")
+  end
+
+  def post_tweet(text, reply_to: nil)
+    if reply_to
+      Rails.configuration.x.twitter_client.tweet(text, reply_to:)
+    else
+      Rails.configuration.x.twitter_client.tweet(text)
+    end
   rescue TwitterClient::Error => e
     Sentry.capture_exception(e, extra: { tweet_text: text }, hint: { background: false })
     nil

--- a/app/jobs/tweet_vote_results_job.rb
+++ b/app/jobs/tweet_vote_results_job.rb
@@ -2,6 +2,8 @@
 
 class TweetVoteResultsJob < ApplicationJob
   def perform(kadai, type:)
+    raise "Kadai tweet_id is missing: #{kadai.id}" if kadai.tweet_id.nil?
+
     max_vote_count = kadai.works.where(type:).maximum(:votes_count)
     return if max_vote_count <= 1
 
@@ -11,12 +13,11 @@ class TweetVoteResultsJob < ApplicationJob
       #{top_works.map { |work| "#{work.student.name}『#{work.title}』" }.join("\n")}
       で#{max_vote_count}票です！
       #裏SF創作講座
-      https://genron.sf-ura.site/#{kadai.year}/#{kadai.round}
     TWEET
 
     Sentry.with_scope do |scope|
       scope.set_extras(tweet_text: tweet)
-      Rails.configuration.x.twitter_client.tweet(tweet)
+      Rails.configuration.x.twitter_client.tweet(tweet, reply_to: kadai.tweet_id)
     end
   end
 end

--- a/app/jobs/tweet_work_submitted_job.rb
+++ b/app/jobs/tweet_work_submitted_job.rb
@@ -2,12 +2,14 @@
 
 class TweetWorkSubmittedJob < ApplicationJob
   def perform(work)
-    tweet = Rails.configuration.x.twitter_client.tweet(<<~TWEET)
-      【#{work.class.model_name.human}】@#{work.student.user.twitter_screen_name}『#{work.title}』
+    raise "Kadai tweet_id is missing: #{work.kadai.id}" if work.kadai.tweet_id.nil?
+
+    text = <<~TWEET
+      #{work.class.model_name.human}が投稿されました！
+      @#{work.student.user.twitter_screen_name}『#{work.title}』
       #裏SF創作講座
-      https://genron.sf-ura.site/#{work.kadai.year}/#{work.kadai.round}
-      #{work.url}
     TWEET
+    tweet = Rails.configuration.x.twitter_client.tweet(text, reply_to: work.kadai.tweet_id)
 
     work.update!(tweet_id: tweet.fetch('data').fetch('id'))
   end

--- a/lib/twitter_client.rb
+++ b/lib/twitter_client.rb
@@ -39,8 +39,11 @@ class TwitterClient
     end
   end
 
-  def tweet(text)
-    response = @conn.post('/2/tweets', { text: })
+  def tweet(text, reply_to: nil)
+    body = { text: }
+    body[:reply] = { in_reply_to_tweet_id: reply_to.to_s } if reply_to
+
+    response = @conn.post('/2/tweets', body)
     response.body
   end
 

--- a/spec/jobs/tweet_imported_job_spec.rb
+++ b/spec/jobs/tweet_imported_job_spec.rb
@@ -39,17 +39,17 @@ RSpec.describe TweetImportedJob do
       )
     end
     let(:student) { create(:student, name: 'フジ・ナカハラ') }
-
     let(:twitter_client) { instance_double(TwitterClient) }
 
     before do
+      create(:user, student:, twitter_screen_name: 'fuji_nakahara')
       allow(Rails.configuration.x).to receive(:twitter_client).and_return(twitter_client)
       allow(twitter_client).to receive(:tweet).and_return(
         { 'data' => { 'id' => '1234567890123456789' } },
       )
     end
 
-    it 'tweets new kadais, kougais and jissakus' do
+    it 'tweets new kadais and grouped works as replies' do
       described_class.perform_now
 
       expect(twitter_client).to have_received(:tweet).with(<<~KADAI_TWEEET.chomp)
@@ -61,19 +61,53 @@ RSpec.describe TweetImportedJob do
         https://school.genron.co.jp/works/sf/2019/subjects/1/
         https://genron.sf-ura.site/2019/1
       KADAI_TWEEET
-      expect(twitter_client).to have_received(:tweet).with(<<~KOUGAI_TWEEET.chomp)
-        【梗概】フジ・ナカハラ『コウガイ』
+      expected_kougai_tweet = <<~KOUGAI_TWEEET.chomp
+        梗概が投稿されました！
+        フジ・ナカハラ @fuji_nakahara『コウガイ』
         #SF創作講座
-        http://example.com/k
       KOUGAI_TWEEET
-      expect(twitter_client).to have_received(:tweet).with(<<~JISSAKU_TWEEET.chomp)
-        【実作】フジ・ナカハラ『ジッサク』
+      expect(twitter_client).to have_received(:tweet).with(
+        expected_kougai_tweet,
+        reply_to: 1_234_567_890_123_456_789,
+      )
+      expected_jissaku_tweet = <<~JISSAKU_TWEEET.chomp
+        実作が投稿されました！
+        フジ・ナカハラ @fuji_nakahara『ジッサク』
         #SF創作講座
-        http://example.com/j
       JISSAKU_TWEEET
+      expect(twitter_client).to have_received(:tweet).with(
+        expected_jissaku_tweet,
+        reply_to: 1_234_567_890_123_456_789,
+      )
       expect(kadai.reload.tweet_id).not_to be_nil
       expect(kougai.reload.tweet_id).not_to be_nil
       expect(jissaku.reload.tweet_id).not_to be_nil
+    end
+
+    it 'splits grouped work tweets when they exceed the length limit' do
+      kadai.update!(tweet_id: 987_654_321_098_765_432)
+      [kougai, jissaku].each(&:destroy!)
+      works = create_list(
+        :kougai,
+        4,
+        kadai:,
+        student:,
+        title: 'あ' * 40,
+        tweet_id: nil,
+      )
+
+      allow(twitter_client).to receive(:tweet).and_return(
+        { 'data' => { 'id' => '111' } },
+        { 'data' => { 'id' => '222' } },
+      )
+
+      described_class.perform_now
+
+      expect(twitter_client).to have_received(:tweet).twice
+      expect(works[0].reload.tweet_id).to eq(111)
+      expect(works[1].reload.tweet_id).to eq(111)
+      expect(works[2].reload.tweet_id).to eq(222)
+      expect(works[3].reload.tweet_id).to eq(222)
     end
   end
 end

--- a/spec/jobs/tweet_imported_job_spec.rb
+++ b/spec/jobs/tweet_imported_job_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe TweetImportedJob do
 
     it 'splits grouped work tweets when they exceed the length limit' do
       kadai.update!(tweet_id: 987_654_321_098_765_432)
-      [kougai, jissaku].each(&:destroy!)
+      [kougai, jissaku].each { |work| work.update!(tweet_id: 123) }
       works = create_list(
         :kougai,
         4,

--- a/spec/jobs/tweet_vote_results_job_spec.rb
+++ b/spec/jobs/tweet_vote_results_job_spec.rb
@@ -4,7 +4,14 @@ require 'rails_helper'
 
 RSpec.describe TweetVoteResultsJob do
   describe '#perform' do
-    let(:kadai) { create(:kadai, term: create(:term, year: 2020), round: 1) }
+    let(:kadai) do
+      create(
+        :kadai,
+        term: create(:term, year: 2020),
+        round: 1,
+        tweet_id: 987_654_321_098_765_432,
+      )
+    end
     let(:twitter_client) { instance_spy(TwitterClient) }
 
     before do
@@ -23,13 +30,16 @@ RSpec.describe TweetVoteResultsJob do
       it 'tweets vote results for kougai' do
         described_class.perform_now(kadai, type:)
 
-        expect(twitter_client).to have_received(:tweet).with(<<~TWEET.chomp)
+        expected_tweet = <<~TWEET.chomp
           現時点での第1回梗概の最高得票作は
           フジ・ナカハラ『式年遷皇』
           で2票です！
           #裏SF創作講座
-          https://genron.sf-ura.site/2020/1
         TWEET
+        expect(twitter_client).to have_received(:tweet).with(
+          expected_tweet,
+          reply_to: 987_654_321_098_765_432,
+        )
       end
     end
 
@@ -46,14 +56,17 @@ RSpec.describe TweetVoteResultsJob do
       it 'tweets vote results for jissaku' do
         described_class.perform_now(kadai, type:)
 
-        expect(twitter_client).to have_received(:tweet).with(<<~TWEET.chomp)
+        expected_tweet = <<~TWEET.chomp
           現時点での第1回実作の最高得票作は
           フジ・ナカハラ『サイボーグ・クラスメイト』
           フジ・ナカハラ『透明な血のつながり』
           で2票です！
           #裏SF創作講座
-          https://genron.sf-ura.site/2020/1
         TWEET
+        expect(twitter_client).to have_received(:tweet).with(
+          expected_tweet,
+          reply_to: 987_654_321_098_765_432,
+        )
       end
     end
   end

--- a/spec/jobs/tweet_work_submitted_job_spec.rb
+++ b/spec/jobs/tweet_work_submitted_job_spec.rb
@@ -7,7 +7,12 @@ RSpec.describe TweetWorkSubmittedJob do
     let(:work) do
       create(
         :kougai,
-        kadai: create(:kadai, term: create(:term, year: 2020), round: 2),
+        kadai: create(
+          :kadai,
+          term: create(:term, year: 2020),
+          round: 2,
+          tweet_id: 987_654_321_098_765_432,
+        ),
         title: '小説つばる「新人SF作家特集号」の依頼',
         url: 'https://kakuyomu.jp/works/1177354054935195606/episodes/1177354054935195646',
         tweet_id: nil,
@@ -26,12 +31,15 @@ RSpec.describe TweetWorkSubmittedJob do
     it 'tweets and saves tweet_id on the given work' do
       described_class.perform_now(work)
 
-      expect(twitter_client).to have_received(:tweet).with(<<~TWEET)
-        【梗概】@fuji_nakahara『小説つばる「新人SF作家特集号」の依頼』
+      expected_tweet = <<~TWEET
+        梗概が投稿されました！
+        @fuji_nakahara『小説つばる「新人SF作家特集号」の依頼』
         #裏SF創作講座
-        https://genron.sf-ura.site/2020/2
-        https://kakuyomu.jp/works/1177354054935195606/episodes/1177354054935195646
       TWEET
+      expect(twitter_client).to have_received(:tweet).with(
+        expected_tweet,
+        reply_to: 987_654_321_098_765_432,
+      )
       expect(work.reload.tweet_id).not_to be_nil
     end
   end


### PR DESCRIPTION
- close #1747

X API の URL 付きポスト課金増に対応するため、作品・投票結果のポストを課題ポストへのリプライに寄せます。

課題ポストは従来通り URL 付きの導線として残し、作品ポストは URL を外して課題・種別ごとにまとめます。X の文字数判定に合わせるため、まとめ投稿の分割には twitter-text の weighted length を使います。